### PR TITLE
back @testing-library/dom to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "@jest/globals": "^29.5.0",
-    "@testing-library/dom": "^9.0.1",
+    "@testing-library/dom": "^8.20.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",


### PR DESCRIPTION
`@testing-library/dom` is also a dependency of `jest-config-stripes` and we want it to act like a peer-dep, i.e. we only want a single version in our bundle so that jest doesn't get confused. It may be that there's a better way to do configure this, but since we're relying on this package's deps being hoisted by the UI app that depends on this one, this seems like the easiest way to accomplish that.