### PR TITLE
correctly group mod-descriptor conditionals

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -159,14 +159,14 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Read module descriptor
-        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' && github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' && (github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main') }}
         id: moduleDescriptor
         uses: juliangruber/read-file-action@v1
         with:
           path: ./module-descriptor.json
 
       - name: Publish module descriptor
-        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' && github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' && (github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main') }}
         id: modDescriptorPost
         uses: fjogeleit/http-request-action@master
         with:


### PR DESCRIPTION
The module-descriptor should be published if PUBLISH_MOD_DESCRIPTOR is true and the destination branch is the default-branch (`master` or `main`). IOW, we're evaluating `(A && B) || C` when we want `A && (B || C)`. Whoops.

This error appears to be widespread but hasn't been picked up because most UI repos have their default branch as `master`, meaning we end upwith a conditional like `false && true || false` (which evaluates to false) but here we end up with `false && true || true` (which evaluates to true).