### PR TITLE
expand pure-ESM list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 * Provide `jest` v29, `@testing-library/*`, and related deps.
 * Re-export `@testing-library/*`.
+* Keep a list of pure-ESM modules which must be transpiled for jest.

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const path = require('path');
 const esModules = [
   '@folio',
   '@json2csv',
+  'decode-uri-component',
+  'filter-obj',
   'find-up',
   'get-stdin',
   'global-dirs',
@@ -19,7 +21,8 @@ const esModules = [
   'query-string',
   'resolve-from',
   'resolve-pkg',
-  'uuid'
+  'split-on-first',
+  'uuid',
 ].join('|');
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,21 @@ const path = require('path');
 // on publish. this list puts things _back_ on the list of those needing
 // transpilation and includes any module that is distributed uncompiled
 // as pure-ESM.
-const esModules = ['@folio', '@json2csv', 'ky', 'uuid'].join('|');
+const esModules = [
+  '@folio',
+  '@json2csv',
+  'find-up',
+  'get-stdin',
+  'global-dirs',
+  'import-lazy',
+  'inquirer',
+  'is-path-inside',
+  'ky',
+  'query-string',
+  'resolve-from',
+  'resolve-pkg',
+  'uuid'
+].join('|');
 
 module.exports = {
   collectCoverageFrom: [


### PR DESCRIPTION
Jest assumes everything in node_modules has been transpiled. This causes it to choke on modules distributed as pure ESM, so we keep a manual list of such modules to put back on the 'please transpile' list so Jest can handle them.