### PR TITLE
remove @testing-library/react-hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@testing-library/dom": "^9.3.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
     "babel-jest": "^29.5.0",
     "babel-plugin-module-resolver": "^5.0.0",


### PR DESCRIPTION
For React v18, the functionality previously provided by @testing-library/react-hooks has been integrated directly into @testing-library/react v14.