### PR TITLE
export esModules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.1.0 IN PROGRESS
 
+* Export `esModules`, allowing consumers to leverage it in their own `transformIgnorePatterns` config.
+
 ## [2.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v2.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v1.0.0...v2.0.0)
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = {
   ],
   coverageDirectory: './artifacts/coverage-jest/',
   coverageReporters: ['lcov'],
+  esModules,
   moduleNameMapper: {
     '^.+\\.(css|png|svg)$': 'identity-obj-proxy',
   },


### PR DESCRIPTION
Export `esModules`, allowing consuming modules to leverage the values here in their own `transformIgnorePatterns` settings.