### PR TITLE
Revert "export esModules"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 2.1.0 IN PROGRESS
 
-* Export `esModules`, allowing consumers to leverage it in their own `transformIgnorePatterns` config.
 * Transform `ts`, `tsx` files in addition to `js`, `jsx`.
 
 ## [2.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v2.0.0) (2023-10-11)

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ module.exports = {
   ],
   coverageDirectory: './artifacts/coverage-jest/',
   coverageReporters: ['lcov'],
-  esModules,
   moduleNameMapper: {
     '^.+\\.(css|png|svg)$': 'identity-obj-proxy',
   },


### PR DESCRIPTION
Revert Lucky PR #13. Because this config is used in consuming modules like
```
"extends": "@folio/eslint-config-stripes",
```
jest with throw an error when it sees config params it does not recognize:

> ● Validation Warning:
>
>  Unknown option "esModules" with value "@folio|@json2csv|decode-uri-component|filter-obj|find-up|get-stdin|global-dirs|import-lazy|inquirer|is-path-inside|ky|query-string|resolve-from|resolve-pkg|split-on-first|uuid" was found.
>  This is probably a typing mistake. Fixing it will remove this message.
>
>  Configuration Documentation: