### PR TITLE
do not publish module descriptor

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -12,3 +12,5 @@ jobs:
       jest-enabled: false
       sonar-enabled: false
       compile-translations: false
+      publish-module-descriptor: false
+


### PR DESCRIPTION
This repository is for development only had therefore has no module descriptor to publish.