### PR TITLE
loosen github workflow constraint to ^1.0.0

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ui:
-    uses: folio-org/.github/.github/workflows/ui.yml@v1.6
+    uses: folio-org/.github/.github/workflows/ui.yml@v1
     secrets: inherit
     with:
       jest-enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Transform `ts`, `tsx` files in addition to `js`, `jsx`.
 * *BREAKING* @folio/stripes-webpack 6
+* Loosen GA workflow compatibility to `^1.0.0`.
 
 ## [2.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v2.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v1.0.0...v2.0.0)


### PR DESCRIPTION
Use `@1` instead of `@1.whatever` to provide `^1.0.0` compatibility with GithubActions workflow releases.