### PR TITLE
Add `jspdf` polyfills and include it in esModules list to support `jspdf` v4 in jest configuration.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const esModules = [
   'import-lazy',
   'inquirer',
   'is-path-inside',
+  'jspdf',
   'ky',
   'query-string',
   'resolve-from',

--- a/jest-setupFiles.js
+++ b/jest-setupFiles.js
@@ -1,1 +1,9 @@
 import 'regenerator-runtime/runtime';
+import {
+  TextEncoder,
+  TextDecoder,
+} from 'util';
+
+// Polyfills for jspdf
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;


### PR DESCRIPTION
## Description
`jspdf` was bumped from `^3.0.0` (EOL) to `^4.0.0` in https://github.com/folio-org/ui-users/pull/3005, and tests failed.

1. Fix `SyntaxError: Cannot use import statement outside a module` by adding `jspdf` in `transformIgnorePatterns` - this package is distributed as an ESM module and needs to be transformed by Babel during testing. 
2. Then the  `ReferenceError: TextEncoder is not defined` error appears - is fixed by adding `TextEncoder` and `TextDecoder` polyfills, which are required by jspdf's dependencies, but not available in the Node/Jest environment.
 
