### PR TITLE
specify correct file extension for test in TypeScript files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0 IN PROGRESS
 
 * Want to reexport `@testing-library/react-hooks`? Better depend on it. Refs STRIPES-1014.
+* Fix typo in `index.js` (`tx` instead of `ts`).
 
 ## [3.0.2](https://github.com/folio-org/eslint-config-stripes/tree/v3.0.2) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v3.0.2...v3.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.1.0 IN PROGRESS
 
 * Want to reexport `@testing-library/react-hooks`? Better depend on it. Refs STRIPES-1014.
-* Fix typo in `index.js` (`tx` instead of `ts`).
+* Fix typo, allowing .ts test files to be properly recognized.
 
 ## [3.0.2](https://github.com/folio-org/eslint-config-stripes/tree/v3.0.2) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v3.0.2...v3.0.1)

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
     'jest-location-mock',
   ],
   testEnvironment: 'jsdom',
-  testMatch: ['**/(lib|src)/**/?(*.)test.{js,jsx,tx,tsx}'],
+  testMatch: ['**/(lib|src)/**/?(*.)test.{js,jsx,ts,tsx}'],
   testPathIgnorePatterns: ['/node_modules/', '/test/bigtest/', '/test/ui-testing/'],
   transform: { '^.+\\.(js|jsx|ts|tsx)$': path.join(__dirname, './jest-transformer.js') },
   transformIgnorePatterns: [`/node_modules/(?!${esModules})`],


### PR DESCRIPTION
Is the `.tx` here an typo? Shouldn't it be `.ts` istead?
` testMatch: ['**/(lib|src)/**/?(*.)test.{js,jsx,tx,tsx}'],`