### PR TITLE
STRIPES-1020 Ship TypeScript declarations for testing-library/* re-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Want to reexport `@testing-library/react-hooks`? Better depend on it. Refs STRIPES-1014.
 * Fix typo, allowing .ts test files to be properly recognized.
+* Ship TypeScript declarations for `testing-library/*` re-exports. Refs STRIPES-1020.
 
 ## [3.0.2](https://github.com/folio-org/eslint-config-stripes/tree/v3.0.2) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v3.0.2...v3.0.1)

--- a/testing-library/dom/index.d.ts
+++ b/testing-library/dom/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from '@testing-library/dom';
+export * from '@testing-library/dom';

--- a/testing-library/jest-dom/index.d.ts
+++ b/testing-library/jest-dom/index.d.ts
@@ -1,0 +1,1 @@
+export * from '@testing-library/jest-dom';

--- a/testing-library/react-hooks/index.d.ts
+++ b/testing-library/react-hooks/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from '@testing-library/react-hooks';
+export * from '@testing-library/react-hooks';

--- a/testing-library/react/index.d.ts
+++ b/testing-library/react/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from '@testing-library/react';
+export * from '@testing-library/react';

--- a/testing-library/user-event/index.d.ts
+++ b/testing-library/user-event/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from '@testing-library/user-event';
+export * from '@testing-library/user-event';


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STRIPES-1020

## Purpose

The `@folio/jest-config-stripes` package re-exports five `@testing-library/*` packages under `testing-library/{react,user-event,dom,jest-dom,react-hooks}`. Each subdirectory provides an `index.js` re-export but no companion `.d.ts`, so TypeScript consumers hit TS7016 errors and fall back to `any`, even though the upstream packages already ship their own declarations. This forces individual repositories to maintain local declaration shims and erodes type safety in test files.

## Approach

- Added `index.d.ts` next to each `testing-library/*/index.js`, mirroring the runtime re-export at the type level (e.g. `export * from '@testing-library/react';`, plus a `default` re-export where applicable).
- Updated `CHANGELOG.md` to record the change.