### PR TITLE
STRIPES-1021 align collectCoverageFrom extensions with testMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Want to reexport `@testing-library/react-hooks`? Better depend on it. Refs STRIPES-1014.
 * Fix typo, allowing .ts test files to be properly recognized.
 * Ship TypeScript declarations for `testing-library/*` re-exports. Refs STRIPES-1020.
+* Align `collectCoverageFrom` extensions with `testMatch` to include `.ts` and `.tsx`. Refs STRIPES-1021.
 
 ## [3.0.2](https://github.com/folio-org/eslint-config-stripes/tree/v3.0.2) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v3.0.2...v3.0.1)

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const esModules = [
 
 module.exports = {
   collectCoverageFrom: [
-    '**/(lib|src)/**/*.{js,jsx}',
+    '**/(lib|src)/**/*.{js,jsx,ts,tsx}',
     '!**/node_modules/**',
     '!**/test/jest/**',
   ],


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STRIPES-1021

## Purpose

The shared Jest configuration in `@folio/jest-config-stripes` (`index.js`) has misaligned glob patterns between `testMatch` and `collectCoverageFrom`. `testMatch` includes TypeScript via `**/(lib|src)/**/?(*.)test.{js,jsx,ts,tsx}`, but `collectCoverageFrom` globs only `**/(lib|src)/**/*.{js,jsx}`. As a result, TypeScript source files are executed in tests but never measured for code coverage.

## Approach

Extend the `collectCoverageFrom` glob in `index.js` to `**/(lib|src)/**/*.{js,jsx,ts,tsx}` so coverage collection matches the extensions already accepted by `testMatch`.